### PR TITLE
fix for lte_cqi and rate_control

### DIFF
--- a/examples/lte_cqi/README.md
+++ b/examples/lte_cqi/README.md
@@ -105,7 +105,7 @@ pip3 install -r requirements.txt
 Run ns-3 example with two shell window:
 ```shell
 cp -r contrib/ns3-ai/examples/lte_cqi scratch/
-./waf --run "lte_cqi"
+./ns3 run lte_cqi
 ```
 Open another shell window and Run Python code:
 ```shell

--- a/examples/lte_cqi/README.md
+++ b/examples/lte_cqi/README.md
@@ -14,13 +14,14 @@ Unlike the RL_TCP example, in this example, we want to show how to change the so
 
 ### Simulation scenario
 This scenario is implemented to test the performance of high-speed situations, and multi-users are attached to the base station to test the downlink scheduling performance.
+
 <img src="figures/scene1.png" alt="scenario" width="200"/>
 
 
 ### Performance Metrics
 - Calculate the MSE of the outdated CQI and predicted CQI
-- Compare the MSE, calculate the rate of the prediction (usage rate)
-- Using Radom Robin as a scheduler to see directly the impact of CQI (Every user has an equal number of times scheduled )
+- Map the predicted CQI to MCS and data rate
+- Use Round Robin as a scheduler to see directly the impact of CQI (Every user has an equal number of times scheduled )
 - Mainly concern throughput
 
 
@@ -96,14 +97,14 @@ with dl as data:
 
 
 ## Build and Run
-Check and Intall required packets for the tensorflow:
+Check and Install required packets for the tensorflow:
 ```shell
 pip3 install -r requirements.txt
 ```
 ### Run Separately (no longer recommended)
 Run ns-3 example with two shell window:
 ```shell
-cp -r contrib/ns3-ai/example/lte_cqi scratch/
+cp -r contrib/ns3-ai/examples/lte_cqi scratch/
 ./waf --run "lte_cqi"
 ```
 Open another shell window and Run Python code:
@@ -117,6 +118,7 @@ python3 run_online.py
 ### Run with all-in-one script
 If you want to test the LSTM, you can run another python script but you may need to install [TensorFlow](https://www.tensorflow.org/) environment first. 
 ```shell
+cp -r contrib/ns3-ai/examples/lte_cqi scratch/
 cd scratch/lte_cqi/
 
 python3 run_online_lstm.py 1

--- a/examples/lte_cqi/my-rr-sched.cc
+++ b/examples/lte_cqi/my-rr-sched.cc
@@ -67,6 +67,7 @@ MyRrMacScheduler::MyRrMacScheduler ()
 MyRrMacScheduler::~MyRrMacScheduler ()
 {
   NS_LOG_FUNCTION (this);
+  m_cqiDl->SetFinish();
 }
 
 void

--- a/examples/lte_cqi/run_online_lstm.py
+++ b/examples/lte_cqi/run_online_lstm.py
@@ -118,8 +118,8 @@ train_data = []
 is_train = True
 CQI = 0
 delay_queue = []
-exp = Experiment(1234, 4096, 'lte_cqi', '../../')
-exp.run(show_output=0)
+exp = Experiment(1234, 4096, 'lte_cqi', '../../', using_waf=False)
+exp.run(show_output=1)
 try:
     while True:
         with dl as data:
@@ -130,7 +130,7 @@ try:
             CQI = data.feat.wbCqi
             if CQI > 15:
                 break
-            old_print("get:%d" % CQI)
+            old_print("get: %d" % CQI)
             # CQI = next(get_CQI)
             delay_queue.append(CQI)
             if len(delay_queue) < delta:

--- a/examples/rate-control/README.md
+++ b/examples/rate-control/README.md
@@ -1,22 +1,104 @@
 # Rate Control Example
-This is an example that shows how to develop a new rate control algorithm for the Wi-Fi model in ns-3 using the ns3-ai model.
-## Usage
+There are existing models of constant rate and Thompson sampling algorithms in Wi-Fi module. Here we reimplement 
+them in Python to show how to develop a new rate control algorithm for the Wi-Fi module using ns3-ai.
+
+## Thompson Sampling Algorithm
+
+- In the algorithm, each action has parameters alpha and beta attached to it (and independent with other actions), used to estimate probability of success. 
+Our goal is to find the action with the highest estimated probability of success.
+- Unlike greedy algorithm which estimates probability using counters (success / total), TS algorithm
+estimates by sampling from posterior beta distribution (defined with alpha and beta).
+- By choosing the highest estimated probability, TS probes potentially good actions, avoids 
+unuseful actions, and finally converge at the optimal one.
+
+### Applying TS to MCS selection & policy improvement
+
+- Each MCS is an action, which has two results: successful or failed transmission.
+- When deciding a new MCS, estimate every MCS its probability of transmission success.
+- Select the MCS with the highest estimated probability.
+- After transmission, use the result to update parameters alpha and beta.
+
+## Interaction between ns-3 and ns3-ai
+
+In general, C++ code stores the environment in shared memory (for C++ side, write only,
+for Python side, read only). Python code updates action to another
+part of shared memory (for Python side, write only, for C++ side, read only).
+
+- C++ side (ns-3)
+
+The type of environment indicates different events (e.g. 
+initialization, tx start, tx success, tx failure) that occurs 
+in ns-3 simulation.
+
+For example, in `ai-thompson-sampling-wifi-manager.cc`, type number 
+0x08 tells Python side that function DoGetDataTxVector is being called 
+which requires updating MCS:
+
+```c++
+  // set input, type 0x08
+  auto env = m_ns3ai_mod->EnvSetterCond ();
+  env->type = 0x08;
+  env->managerId = m_ns3ai_manager_id;
+  env->stationId = station->m_ns3ai_station_id;
+  m_ns3ai_mod->SetCompleted ();
+
+  // get output
+  auto act = m_ns3ai_mod->ActionGetterCond ();
+  WifiMode mode = station->m_mcsStats.at (act->res).mode;
+  uint8_t nss = act->stats.nss;
+  uint16_t channelWidth = std::min (act->stats.channelWidth, GetPhy ()->GetChannelWidth ());
+  uint16_t guardInterval = act->stats.guardInterval;
+  m_ns3ai_mod->GetCompleted ();
+```
+
+- Python side (ns3-ai)
+
+Python code handles environment in shared memory according to the type number.
+For example, when a transmission is over (data failed, type 0x05, or data OK, type 0x06), 
+statistics will be updated and an optimal MCS is selected for next transmission.
+
+From `ai_thompson_sampling.py`:
+
+```
+    def do(self, env: AiThompsonSamplingEnv, act: AiThompsonSamplingAct) -> AiThompsonSamplingAct:
+        ...
+        elif env.type == 0x05:  # DoReportDataFailed
+            man = self.wifiManager[env.managerId]
+            sta = self.wifiStation[env.stationId]
+            sta.DoReportDataFailed(env.decay.decay, env.decay.now)
+            man.UpdateNextMode(sta, env.decay.decay, env.decay.now)
+            act.stationId = env.stationId
+        ...
+        elif env.type == 0x06:  # DoReportDataOk
+            man = self.wifiManager[env.managerId]
+            sta = self.wifiStation[env.stationId]
+            sta.DoReportDataOk(env.decay.decay, env.decay.now)
+            man.UpdateNextMode(sta, env.decay.decay, env.decay.now)
+            act.stationId = env.stationId
+```
+
+## Build and run
 
 Copy this example to scratch:
 
 ```shell
-cp -r contrib/ns3-ai/example/rate-control scratch/
+cp -r contrib/ns3-ai/examples/rate-control scratch/
 cd scratch/rate-control
 ```
 
-## 1. Constant Rate Control
+### 1. Constant Rate Control
 
 ```shell
 python3 ai_constant_rate.py
 ```
 
-## 2. Thompson Sampling Rate Control
+### 2. Thompson Sampling Rate Control
 
 ```shell
 python3 ai_thompson_sampling.py
 ```
+
+## Output
+
+Default simulation time is 5 seconds (configured via Command-Line argument `duration`). 
+The delay and throughput is printed every `statInterval` seconds, by default is 0.1s.

--- a/examples/rate-control/ai-constant-rate-wifi-manager.h
+++ b/examples/rate-control/ai-constant-rate-wifi-manager.h
@@ -57,7 +57,7 @@ public:
    * \return the object TypeId
    */
   static TypeId GetTypeId (void);
-  AiConstantRateWifiManager (uint16_t id);
+  AiConstantRateWifiManager (uint16_t id = 2333);
   virtual ~AiConstantRateWifiManager ();
 
 
@@ -73,13 +73,13 @@ private:
                        double dataSnr, uint16_t dataChannelWidth, uint8_t dataNss) override;
   void DoReportFinalRtsFailed (WifiRemoteStation *station) override;
   void DoReportFinalDataFailed (WifiRemoteStation *station) override;
-  WifiTxVector DoGetDataTxVector (WifiRemoteStation *station) override;
+  WifiTxVector DoGetDataTxVector (WifiRemoteStation *station, uint16_t allowedWidth) override;
   WifiTxVector DoGetRtsTxVector (WifiRemoteStation *station) override;
 
   WifiMode m_dataMode; //!< Wifi mode for unicast Data frames
   WifiMode m_ctlMode;  //!< Wifi mode for RTS frames
 
-  uint16_t m_ns3ai_id;
+//  uint16_t m_ns3ai_id;
   Ns3AIRL<AiConstantRateEnv, AiConstantRateAct> * m_ns3ai_mod;
 };
 

--- a/examples/rate-control/ai-thompson-sampling-wifi-manager.cc
+++ b/examples/rate-control/ai-thompson-sampling-wifi-manager.cc
@@ -379,7 +379,7 @@ AiThompsonSamplingWifiManager::GetModeGuardInterval (WifiRemoteStation *st, Wifi
 }
 
 WifiTxVector
-AiThompsonSamplingWifiManager::DoGetDataTxVector (WifiRemoteStation *st)
+AiThompsonSamplingWifiManager::DoGetDataTxVector (WifiRemoteStation *st, uint16_t allowedWidth)
 {
   NS_LOG_FUNCTION (this << st);
   InitializeStation (st);
@@ -416,7 +416,7 @@ AiThompsonSamplingWifiManager::DoGetDataTxVector (WifiRemoteStation *st)
       GetNumberOfAntennas (),
       nss,
       0, // NESS
-      GetChannelWidthForTransmission (mode, channelWidth),
+      GetPhy()->GetTxBandwidth(mode, GetChannelWidth(st)),
       GetAggregation (station),
       false);
 }
@@ -447,13 +447,16 @@ AiThompsonSamplingWifiManager::DoGetRtsTxVector (WifiRemoteStation *st)
   NS_ASSERT (nss == 1);
 
   return WifiTxVector (
-      mode, GetDefaultTxPowerLevel (),
-      GetPreambleForTransmission (mode.GetModulationClass (), GetShortPreambleEnabled ()),
+      mode,
+      GetDefaultTxPowerLevel (),
+      GetPreambleForTransmission (
+          mode.GetModulationClass (),
+          GetShortPreambleEnabled ()),
       guardInterval,
       GetNumberOfAntennas (),
       nss,
       0, // NESS
-      GetChannelWidthForTransmission (mode, channelWidth),
+      channelWidth,
       GetAggregation (station),
       false);
 }

--- a/examples/rate-control/ai-thompson-sampling-wifi-manager.h
+++ b/examples/rate-control/ai-thompson-sampling-wifi-manager.h
@@ -105,7 +105,7 @@ private:
                               double rxSnr, double dataSnr, uint16_t dataChannelWidth, uint8_t dataNss) override;
   void DoReportFinalRtsFailed (WifiRemoteStation *station) override;
   void DoReportFinalDataFailed (WifiRemoteStation *station) override;
-  WifiTxVector DoGetDataTxVector (WifiRemoteStation *station) override;
+  WifiTxVector DoGetDataTxVector (WifiRemoteStation *station, uint16_t allowedWidth) override;
   WifiTxVector DoGetRtsTxVector (WifiRemoteStation *station) override;
 
   /**

--- a/examples/rate-control/ai_constant_rate.py
+++ b/examples/rate-control/ai_constant_rate.py
@@ -60,10 +60,10 @@ class AiConstantRateContainer:
 
 
 if __name__ == '__main__':
-    ns3Settings = {'raa': 'AiConstantRate', 'nWifi': 3, 'standard': '11ac', 'duration': 1}
+    ns3Settings = {'raa': 'AiConstantRate', 'nWifi': 3, 'standard': '11ac', 'duration': 5}
     mempool_key = 1234 # memory pool key, arbitrary integer large than 1000
     mem_size = 4096 # memory pool size in bytes
-    exp = Experiment(mempool_key, mem_size, 'rate-control', '../../')
+    exp = Experiment(mempool_key, mem_size, 'rate-control', '../../', using_waf=False)
     exp.reset()
 
     memblock_key = 2333 # memory block key in the memory pool, arbitrary integer, and need to keep the same in the ns-3 script

--- a/examples/rate-control/ai_thompson_sampling.py
+++ b/examples/rate-control/ai_thompson_sampling.py
@@ -247,10 +247,10 @@ class AiThompsonSamplingContainer:
 
 
 if __name__ == '__main__':
-    ns3Settings = {'raa': 'AiThompsonSampling', 'nWifi': 3, 'standard': '11ac', 'duration': 1}
+    ns3Settings = {'raa': 'AiThompsonSampling', 'nWifi': 3, 'standard': '11ac', 'duration': 5}
     mempool_key = 1234 # memory pool key, arbitrary integer large than 1000
     mem_size = 4096 # memory pool size in bytes
-    exp = Experiment(mempool_key, mem_size, 'rate-control', '../../')
+    exp = Experiment(mempool_key, mem_size, 'rate-control', '../../', using_waf=False)
     exp.reset()
 
     memblock_key = 2333 # memory block key in the memory pool, arbitrary integer, and need to keep the same in the ns-3 script

--- a/examples/rate-control/rate-control.cc
+++ b/examples/rate-control/rate-control.cc
@@ -108,25 +108,17 @@ setWifiStandard (WifiHelper &wifi, const std::string standard)
     {
       wifi.SetStandard (WIFI_STANDARD_80211a);
     }
-  else if (standard == "11n_2_4GHZ")
+  else if (standard == "11n")
     {
-      wifi.SetStandard (WIFI_STANDARD_80211n_2_4GHZ);
-    }
-  else if (standard == "11n_5GHZ")
-    {
-      wifi.SetStandard (WIFI_STANDARD_80211n_5GHZ);
+      wifi.SetStandard (WIFI_STANDARD_80211n);
     }
   else if (standard == "11ac")
     {
       wifi.SetStandard (WIFI_STANDARD_80211ac);
     }
-  else if (standard == "11ax_2_4GHZ")
+  else if (standard == "11ax")
     {
-      wifi.SetStandard (WIFI_STANDARD_80211ax_2_4GHZ);
-    }
-  else if (standard == "11ax_5GHZ")
-    {
-      wifi.SetStandard (WIFI_STANDARD_80211ax_5GHZ);
+      wifi.SetStandard (WIFI_STANDARD_80211ax);
     }
   else
     {
@@ -230,8 +222,8 @@ main (int argc, char *argv[])
 
   WifiHelper wifi;
 
-  // Setting Wifi Standard]
-  setWifiStandard (wifi, standard); // wifi.SetStandard (WIFI_STANDARD_80211ax_5GHZ);
+  // Setting Wifi Standard (enum WifiStandard)
+  setWifiStandard (wifi, standard);
 
   // Setting Raa Algorithm, refer to 'src/wifi/model/rate-control'
   wifi.SetRemoteStationManager (raaAlgo);
@@ -340,7 +332,6 @@ main (int argc, char *argv[])
     }
 
   Simulator::Run ();
-  Simulator::Destroy ();
 
   Ptr<PacketSink> sink1 = DynamicCast<PacketSink> (sinkApps.Get (0));
   std::cout << "Total Bytes Received: " << sink1->GetTotalRx () << std::endl;
@@ -348,5 +339,6 @@ main (int argc, char *argv[])
             << "Mbps" << std::endl;
   std::cout << "Average Delay: " << data.averageDelay () << "ms" << std::endl;
 
+  Simulator::Destroy ();
   return 0;
 }

--- a/model/ns3-ai-dl.h
+++ b/model/ns3-ai-dl.h
@@ -229,7 +229,6 @@ Ns3AIDL<FeatureType, PredictedType, TargetType, SimInfoType>::Ns3AIDL(uint16_t i
   m_info = (SimInfoType *)(m_baseAddr + sizeof(FeatureType) + sizeof(PredictedType) + sizeof(TargetType));
   m_isFinish =
       (bool *)(m_baseAddr + sizeof(FeatureType) + sizeof(PredictedType) + sizeof(TargetType) + sizeof(SimInfoType));
-  Simulator::ScheduleDestroy(&Ns3AIDL<FeatureType, PredictedType, TargetType, SimInfoType>::SetFinish, this);
 }
 
 template <typename FeatureType, typename PredictedType, typename TargetType, typename SimInfoType>

--- a/model/ns3-ai-rl.h
+++ b/model/ns3-ai-rl.h
@@ -195,12 +195,13 @@ Ns3AIRL<EnvType, ActionType, SimInfoType>::Ns3AIRL(uint16_t id)
   m_info = (SimInfoType *)(m_baseAddr + sizeof(EnvType) + sizeof(ActionType));
   m_isFinish =
       (bool *)(m_baseAddr + sizeof(EnvType) + sizeof(ActionType) + sizeof(SimInfoType));
-  Simulator::ScheduleDestroy(&Ns3AIRL<EnvType, ActionType, SimInfoType>::SetFinish, this);
+//  Simulator::ScheduleDestroy(&Ns3AIRL<EnvType, ActionType, SimInfoType>::SetFinish, this);
 }
 
 template <typename EnvType, typename ActionType, typename SimInfoType>
 Ns3AIRL<EnvType, ActionType, SimInfoType>::~Ns3AIRL(void)
 {
+  SetFinish();
 }
 
 template <typename EnvType, typename ActionType, typename SimInfoType>


### PR DESCRIPTION
1. fix lte_cqi build and run error
2. fix a bug of dereferencing NULL pointer, by calling SetFinish() from rr scheduler's destructor, instead of making SetFinish() hooked to Destroy() (which releases the memory occupied by m_isFinish before accessing m_isFinish)
3. doc improvements