### PR TITLE
fix: invalid boost and protobuf link targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ build_lib(
         LIBNAME ai
         SOURCE_FILES ${msg_interface_srcs} ${gym_interface_srcs}
         HEADER_FILES ${msg_interface_hdrs} ${gym_interface_hdrs}
-        LIBRARIES_TO_LINK ${libcore} Boost::program_options protobuf::libprotobuf
+        LIBRARIES_TO_LINK ${libcore} protobuf
 )
 
 # protobuf_generate function is missing in some installations by package manager


### PR DESCRIPTION
fix #102 
on all systems, I tested this on (ubuntu, ArchLinux), there are no `Boost::program_options protobuf::libprotobuf` link targets. Instead, the examples work with `protobuf` only.