### PR TITLE
feat: make gym interface ns3 singleton

### DIFF
--- a/model/gym-interface/cpp/ns3-ai-gym-interface.cc
+++ b/model/gym-interface/cpp/ns3-ai-gym-interface.cc
@@ -41,13 +41,6 @@ namespace ns3
 NS_LOG_COMPONENT_DEFINE("OpenGymInterface");
 NS_OBJECT_ENSURE_REGISTERED(OpenGymInterface);
 
-Ptr<OpenGymInterface>
-OpenGymInterface::Get()
-{
-    NS_LOG_FUNCTION_NOARGS();
-    return *DoGet();
-}
-
 OpenGymInterface::OpenGymInterface()
     : m_simEnd(false),
       m_stopEnvRequested(false),
@@ -365,18 +358,6 @@ OpenGymInterface::SetExecuteActionsCb(Callback<bool, Ptr<OpenGymDataContainer>> 
 }
 
 void
-OpenGymInterface::DoInitialize()
-{
-    NS_LOG_FUNCTION(this);
-}
-
-void
-OpenGymInterface::DoDispose()
-{
-    NS_LOG_FUNCTION(this);
-}
-
-void
 OpenGymInterface::Notify(Ptr<OpenGymEnv> entity)
 {
     NS_LOG_FUNCTION(this);
@@ -388,13 +369,6 @@ OpenGymInterface::Notify(Ptr<OpenGymEnv> entity)
     SetExecuteActionsCb(MakeCallback(&OpenGymEnv::ExecuteActions, entity));
 
     NotifyCurrentState();
-}
-
-Ptr<OpenGymInterface>*
-OpenGymInterface::DoGet()
-{
-    static Ptr<OpenGymInterface> ptr = CreateObject<OpenGymInterface>();
-    return &ptr;
 }
 
 } // namespace ns3

--- a/model/gym-interface/cpp/ns3-ai-gym-interface.h
+++ b/model/gym-interface/cpp/ns3-ai-gym-interface.h
@@ -37,10 +37,9 @@ class OpenGymSpace;
 class OpenGymDataContainer;
 class OpenGymEnv;
 
-class OpenGymInterface : public Object
+class OpenGymInterface : public Singleton<OpenGymInterface>, public Object
 {
   public:
-    static Ptr<OpenGymInterface> Get();
     OpenGymInterface();
     ~OpenGymInterface() override;
     static TypeId GetTypeId();
@@ -68,13 +67,7 @@ class OpenGymInterface : public Object
 
     void Notify(Ptr<OpenGymEnv> entity);
 
-  protected:
-    // Inherited
-    void DoInitialize() override;
-    void DoDispose() override;
-
   private:
-    static Ptr<OpenGymInterface>* DoGet();
     //    static void Delete();
 
     bool m_simEnd;


### PR DESCRIPTION
Singletons are already part of ns3. This makes the `OpenGymInterface` a ns3 singleton, removing obsolete and duplicated logic which is already part of ns3.