### PR TITLE
improvements to debug and deploy ns3-ai

### DIFF
--- a/model/gym-interface/py/ns3ai_gym_env/envs/ns3_environment.py
+++ b/model/gym-interface/py/ns3ai_gym_env/envs/ns3_environment.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Any
 
 import gymnasium as gym
@@ -274,7 +275,12 @@ class Ns3Env(gym.Env):
         return obs, reward, done, False, extraInfo
 
     def __init__(
-        self, targetName, ns3Path, ns3Settings: dict[str, Any] | None = None, debug: bool = False, shmSize=4096
+        self,
+        targetName: str | Path,
+        ns3Path: str,
+        ns3Settings: dict[str, Any] | None = None,
+        debug: bool = False,
+        shmSize=4096,
     ):
         if self._created:
             raise Exception('Error: Ns3Env is singleton')

--- a/model/gym-interface/py/ns3ai_gym_env/envs/ns3_environment.py
+++ b/model/gym-interface/py/ns3ai_gym_env/envs/ns3_environment.py
@@ -273,11 +273,13 @@ class Ns3Env(gym.Env):
         extraInfo = {"info": self.get_extra_info()}
         return obs, reward, done, False, extraInfo
 
-    def __init__(self, targetName, ns3Path, ns3Settings: dict[str, Any] | None = None, shmSize=4096):
+    def __init__(
+        self, targetName, ns3Path, ns3Settings: dict[str, Any] | None = None, debug: bool = False, shmSize=4096
+    ):
         if self._created:
             raise Exception('Error: Ns3Env is singleton')
         self._created = True
-        self.exp = Experiment(targetName, ns3Path, py_binding, shmSize=shmSize)
+        self.exp = Experiment(targetName, ns3Path, py_binding, debug=debug, shmSize=shmSize)
         self.ns3Settings = ns3Settings
 
         self.newStateRx = False

--- a/model/gym-interface/py/ns3ai_gym_env/envs/ns3_environment.py
+++ b/model/gym-interface/py/ns3ai_gym_env/envs/ns3_environment.py
@@ -1,8 +1,10 @@
-import numpy as np
+from typing import Any
+
 import gymnasium as gym
-from gymnasium import spaces
 import messages_pb2 as pb
 import ns3ai_gym_msg_py as py_binding
+import numpy as np
+from gymnasium import spaces
 from ns3ai_utils import Experiment
 
 
@@ -271,7 +273,7 @@ class Ns3Env(gym.Env):
         extraInfo = {"info": self.get_extra_info()}
         return obs, reward, done, False, extraInfo
 
-    def __init__(self, targetName, ns3Path, ns3Settings=None, shmSize=4096):
+    def __init__(self, targetName, ns3Path, ns3Settings: dict[str, Any] | None = None, shmSize=4096):
         if self._created:
             raise Exception('Error: Ns3Env is singleton')
         self._created = True

--- a/python_utils/ns3ai_utils.py
+++ b/python_utils/ns3ai_utils.py
@@ -18,23 +18,26 @@
 #         Muyuan Shen <muyuan_shen@hust.edu.cn>
 
 import os
-import subprocess
-import psutil
-import time
 import signal
+import subprocess
+import time
+from typing import Any
 
+import psutil
 
 SIMULATION_EARLY_ENDING = 0.5   # wait and see if the subprocess is running after creation
 
 
-def get_setting(setting_map):
-    ret = ''
+def get_setting(setting_map: dict[str, Any]) -> str:
+    ret = ""
     for key, value in setting_map.items():
-        ret += ' --{}={}'.format(key, value)
+        ret += f" --{key}"
+        if value:
+            ret += f"={value}"
     return ret
 
 
-def run_single_ns3(path, pname, setting=None, env=None, show_output=False):
+def run_single_ns3(path, pname, setting: dict[str, Any] | None = None, env=None, show_output=False):
     if env is None:
         env = {}
     env.update(os.environ)
@@ -144,7 +147,7 @@ class Experiment:
     # run ns3 script in cmd with the setting being input
     # \param[in] setting : ns3 script input parameters(default : None)
     # \param[in] show_output : whether to show output or not(default : False)
-    def run(self, setting=None, show_output=False):
+    def run(self, setting: dict[str, Any] | None = None, show_output=False):
         self.kill()
         self.simCmd, self.proc = run_single_ns3(
             './', self.targetName, setting=setting, show_output=show_output)


### PR DESCRIPTION
the first patch is a small fix to supply flags (in the form of `--XXX`) to ns3 environments.

the second patch adds a debug option to ns3-ai. Instead of launching the environment directly, `sleep infinity` is executed instead, allowing users to start the ns3 simulation with a debugger and interactively analyze the simulator.

lastly, I implemented the feature to specify the path of a compiled simulation program. ns3-ai then does not use the `ns3` wrapper but starts the simulation binary directly