### PR TITLE
feat: use dict for extra infos

### DIFF
--- a/model/gym-interface/cpp/ns3-ai-gym-env.h
+++ b/model/gym-interface/cpp/ns3-ai-gym-env.h
@@ -71,7 +71,7 @@ class OpenGymEnv : public Object
     /**
      * Get extra information
      */
-    virtual std::string GetExtraInfo() = 0;
+    virtual std::map<std::string, std::string> GetExtraInfo() = 0;
 
     /**
      * Execute actions. E.g., modify the contention window in TCP.

--- a/model/gym-interface/cpp/ns3-ai-gym-interface.cc
+++ b/model/gym-interface/cpp/ns3-ai-gym-interface.cc
@@ -147,7 +147,7 @@ OpenGymInterface::NotifyCurrentState()
     Ptr<OpenGymDataContainer> obsDataContainer = GetObservation();
     float reward = GetReward();
     bool isGameOver = IsGameOver();
-    std::string extraInfo = GetExtraInfo();
+    std::map<std::string, std::string> extraInfo = GetExtraInfo();
     ns3_ai_gym::EnvStateMsg envStateMsg;
     // observation
     ns3_ai_gym::DataContainer obsDataContainerPbMsg;
@@ -173,7 +173,10 @@ OpenGymInterface::NotifyCurrentState()
         }
     }
     // extra info
-    envStateMsg.set_info(extraInfo);
+    for (auto const &[key, value] : extraInfo)
+    {
+        (*envStateMsg.mutable_info())[key] = value;
+    }
 
     // get the interface
     Ns3AiMsgInterfaceImpl<Ns3AiGymMsg, Ns3AiGymMsg>* msgInterface =
@@ -298,11 +301,11 @@ OpenGymInterface::IsGameOver()
     return (gameOver || m_simEnd);
 }
 
-std::string
+std::map<std::string, std::string>
 OpenGymInterface::GetExtraInfo()
 {
     NS_LOG_FUNCTION(this);
-    std::string info;
+    std::map<std::string, std::string> info;
     if (!m_extraInfoCb.IsNull())
     {
         info = m_extraInfoCb();
@@ -353,7 +356,7 @@ OpenGymInterface::SetGetRewardCb(Callback<float> cb)
 }
 
 void
-OpenGymInterface::SetGetExtraInfoCb(Callback<std::string> cb)
+OpenGymInterface::SetGetExtraInfoCb(Callback<std::map<std::string, std::string>> cb)
 {
     m_extraInfoCb = cb;
 }

--- a/model/gym-interface/cpp/ns3-ai-gym-interface.h
+++ b/model/gym-interface/cpp/ns3-ai-gym-interface.h
@@ -55,7 +55,7 @@ class OpenGymInterface : public Object
     Ptr<OpenGymDataContainer> GetObservation();
     float GetReward();
     bool IsGameOver();
-    std::string GetExtraInfo();
+    std::map<std::string, std::string> GetExtraInfo();
     bool ExecuteActions(Ptr<OpenGymDataContainer> action);
 
     void SetGetActionSpaceCb(Callback<Ptr<OpenGymSpace>> cb);
@@ -63,7 +63,7 @@ class OpenGymInterface : public Object
     void SetGetObservationCb(Callback<Ptr<OpenGymDataContainer>> cb);
     void SetGetRewardCb(Callback<float> cb);
     void SetGetGameOverCb(Callback<bool> cb);
-    void SetGetExtraInfoCb(Callback<std::string> cb);
+    void SetGetExtraInfoCb(Callback<std::map<std::string, std::string>> cb);
     void SetExecuteActionsCb(Callback<bool, Ptr<OpenGymDataContainer>> cb);
 
     void Notify(Ptr<OpenGymEnv> entity);
@@ -86,7 +86,7 @@ class OpenGymInterface : public Object
     Callback<bool> m_gameOverCb;
     Callback<Ptr<OpenGymDataContainer>> m_obsCb;
     Callback<float> m_rewardCb;
-    Callback<std::string> m_extraInfoCb;
+    Callback<std::map<std::string, std::string>> m_extraInfoCb;
     Callback<bool, Ptr<OpenGymDataContainer>> m_actionCb;
 };
 

--- a/model/gym-interface/messages.proto
+++ b/model/gym-interface/messages.proto
@@ -114,7 +114,7 @@ message EnvStateMsg {
 		GameOver = 1;
 	}
 	Reason reason = 4;
-	string info = 5;
+	map<string, string> info = 5;
 }
 
 message EnvActMsg {

--- a/model/gym-interface/py/ns3ai_gym_env/envs/ns3_environment.py
+++ b/model/gym-interface/py/ns3ai_gym_env/envs/ns3_environment.py
@@ -163,9 +163,7 @@ class Ns3Env(gym.Env):
         if self.gameOver:
             self.send_close_command()
 
-        self.extraInfo = envStateMsg.info
-        if not self.extraInfo:
-            self.extraInfo = {}
+        self.extraInfo = dict(envStateMsg.info)
 
         self.newStateRx = True
 
@@ -268,7 +266,7 @@ class Ns3Env(gym.Env):
         obs = self.get_obs()
         reward = self.get_reward()
         done = self.is_game_over()
-        extraInfo = {"info": self.get_extra_info()}
+        extraInfo = self.get_extra_info()
         return obs, reward, done, False, extraInfo
 
     def __init__(self, targetName, ns3Path, ns3Settings=None, shmSize=4096):


### PR DESCRIPTION
allows specifying a dictionary for the extra infos directly. Alternativly, we had to (json?) encode the info we wanted to log somehow.