### PR TITLE
Gymnasium api improvements

### DIFF
--- a/model/gym-interface/cpp/spaces.cc
+++ b/model/gym-interface/cpp/spaces.cc
@@ -247,6 +247,15 @@ OpenGymBoxSpace::GetSpaceDescription()
         boxSpacePb.add_shape(*i);
     }
 
+    for (const auto& low : m_lowVec)
+    {
+        boxSpacePb.add_lows(low);
+    }
+    for (const auto& high : m_highVec)
+    {
+        boxSpacePb.add_highs(high);
+    }
+
     boxSpacePb.set_dtype(m_dtype);
     desc.mutable_space()->PackFrom(boxSpacePb);
     return desc;

--- a/model/gym-interface/messages.proto
+++ b/model/gym-interface/messages.proto
@@ -50,6 +50,8 @@ message BoxSpace {
 	float high = 2;
 	Dtype dtype = 3;
 	repeated uint32 shape = 4;
+	repeated float lows = 5;
+	repeated float highs = 6;
 }
 
 message TupleSpace {

--- a/model/gym-interface/py/ns3ai_gym_env/envs/ns3_environment.py
+++ b/model/gym-interface/py/ns3ai_gym_env/envs/ns3_environment.py
@@ -267,9 +267,15 @@ class Ns3Env(gym.Env):
     def get_state(self):
         obs = self.get_obs()
         reward = self.get_reward()
-        done = self.is_game_over()
+        terminated = False
+        truncated = False
+        if self.is_game_over():
+            if self.gameOverReason == 1:
+                terminated = True  # end because the agent reached its final state
+            else:
+                truncated = True  # end because the simulation ended (for this agent)
         extraInfo = {"info": self.get_extra_info()}
-        return obs, reward, done, False, extraInfo
+        return obs, reward, terminated, truncated, extraInfo
 
     def __init__(self, targetName, ns3Path, ns3Settings=None, shmSize=4096):
         if self._created:

--- a/model/gym-interface/py/ns3ai_gym_env/envs/ns3_environment.py
+++ b/model/gym-interface/py/ns3ai_gym_env/envs/ns3_environment.py
@@ -19,8 +19,8 @@ class Ns3Env(gym.Env):
         elif spaceDesc.type == pb.Box:
             boxSpacePb = pb.BoxSpace()
             spaceDesc.space.Unpack(boxSpacePb)
-            low = boxSpacePb.low
-            high = boxSpacePb.high
+            low = np.array(boxSpacePb.lows) if boxSpacePb.lows else boxSpacePb.low
+            high = np.array(boxSpacePb.highs) if boxSpacePb.highs else boxSpacePb.high
             shape = tuple(boxSpacePb.shape)
             mtype = boxSpacePb.dtype
 


### PR DESCRIPTION
The first patch implements the missing logic for `m_highVec` and `m_lowVec`. The user can either specify the shape via a single value or a vector (corresponding to the shape of the corresponding index). Before, it was simply unused and ignored.

The second patch send `terminated` or `truncated` signals dynamically, depending on whether a `game_over` message was sent. 