### PR TITLE
bug fixs and doc update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,17 @@ if(HAVE_STDINT_H)
     add_definitions(-DHAVE_STDINT_H)
 endif()
 
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    add_compile_options("-Wno-gcc-compat")
+endif()
+
 find_package(Boost REQUIRED COMPONENTS program_options)
 include_directories(${Boost_INCLUDE_DIRS})
 find_package(Python REQUIRED COMPONENTS Interpreter Development)
+if (Python_FOUND)
+    message(STATUS "Python include directories: ${Python_INCLUDE_DIRS}")
+    message(STATUS "Python library directories: ${Python_LIBRARY_DIRS}")
+endif()
 find_package(pybind11 CONFIG REQUIRED)
 include_directories(${pybind11_INCLUDE_DIRS})
 
@@ -72,13 +80,6 @@ set(gym_interface_hdrs
         model/gym-interface/cpp/spaces.h
 )
 
-build_lib(
-        LIBNAME ai
-        SOURCE_FILES ${msg_interface_srcs} ${gym_interface_srcs}
-        HEADER_FILES ${msg_interface_hdrs} ${gym_interface_hdrs}
-        LIBRARIES_TO_LINK ${libcore} protobuf
-)
-
 # protobuf_generate function is missing in some installations by package manager
 check_function_exists(protobuf_generate protobuf_generate_exists)
 if(${protobuf_generate_exists})
@@ -101,6 +102,13 @@ protobuf_generate(
         IMPORT_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/model/gym-interface"
         LANGUAGE python
         PROTOC_OUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/model/gym-interface/py"
+)
+
+build_lib(
+        LIBNAME ai
+        SOURCE_FILES ${msg_interface_srcs} ${gym_interface_srcs}
+        HEADER_FILES ${msg_interface_hdrs} ${gym_interface_hdrs}
+        LIBRARIES_TO_LINK ${libcore} protobuf::libprotobuf
 )
 add_dependencies(${libai} proto-objects)
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,6 +1,6 @@
 # ns3-ai Installation
 
-This installation works on Ubuntu 22.04 and macOS 13.0 or higher.
+This installation works on Ubuntu 22.04 and macOS 15.0 or higher.
 
 ## Requirements
 
@@ -14,17 +14,13 @@ This installation works on Ubuntu 22.04 and macOS 13.0 or higher.
     - Ubuntu: `sudo apt install pybind11-dev`
     - macOS: `brew install pybind11`
 4. A Python virtual environment dedicated for ns3-ai (highly recommended)
-    - Why: 
-        - Separate your ns3-ai dependencies from your other Python-based projects. (Why being virtual)
-        - In build process of ns3-ai examples, Python binding modules are built using system Python libraries (installed with `apt` or `brew`), while your scripts are interpreted with environmental Python (possibly created and activated with `conda`, for your another project). Version mismatch between those Python environments may cause error in your Python script (possibly some modules could not be found). (Why being dedicated)
-    - How:
-        - Check your version of system-wide installed Python: Find the version of Python in the output of `apt list --installed` (Ubuntu) or `brew list` (macOS). If two or more versions are found, keep only one version.
-        - Create a conda virtual environment of the same version: `conda create -n ns3ai_env python=<version found in previous step>`
-        - Activate the virtual and dedicated Python environment for ns3-ai: `conda activate ns3ai_env`
+    - For example, to use conda to create an environment named `ns3ai_env` with python version 3.11: `conda create -n ns3ai_env python=3.11`.
 
 ## General Setup
 
-1. Clone this repository at `contrib/ai`
+1. If a Python virtual environment is used, activate it. The absolute path to the Python executable of this environment, denoted as `<path-to-python>`, will be later passed to cmake via `ns3` script. You can find the path by first activate it and then `which python`.
+
+2. Clone this repository at `contrib/ai`
 
 ```shell
 cd YOUR_NS3_DIRECTORY
@@ -34,12 +30,11 @@ git clone https://github.com/hust-diangroup/ns3-ai.git contrib/ai
 2. Configure and build the `ai` library
 
 ```shell
-./ns3 configure --enable-examples
+./ns3 configure --enable-examples -- -DPython_EXECUTABLE=<path-to-python> -DPython3_EXECUTABLE=<path-to-python>
 ./ns3 build ai
 ```
 
-3. Setup Python interfaces. It's recommended to use a separate Conda environment
-for ns3-ai.
+3. Setup Python interfaces.
 
 ```shell
 pip install -e contrib/ai/python_utils

--- a/examples/lte-cqi/use-msg/run_online_lstm.py
+++ b/examples/lte-cqi/use-msg/run_online_lstm.py
@@ -65,7 +65,7 @@ lstm_input_vec = Input(shape=(input_len, 1), name="input_vec")
 dense1 = Dense(30, activation='selu', kernel_regularizer='l1',)(
     lstm_input_vec[:, :, 0])
 old_print(dense1)
-lstm_l1_mse = K.expand_dims(dense1, axis=-1)
+lstm_l1_mse = tf.keras.ops.expand_dims(dense1, axis=-1)
 lstm_mse = LSTM(20)(lstm_l1_mse)
 predict_lstm_mse = Dense(1)(lstm_mse)
 lstm_model_mse = keras.Model(inputs=lstm_input_vec, outputs=predict_lstm_mse)

--- a/examples/multi-bss/auto-mcs-wifi-manager.h
+++ b/examples/multi-bss/auto-mcs-wifi-manager.h
@@ -61,18 +61,18 @@ class AutoMcsWifiManager : public WifiRemoteStationManager
                         double ackSnr,
                         WifiMode ackMode,
                         double dataSnr,
-                        uint16_t dataChannelWidth,
+                        MHz_u dataChannelWidth,
                         uint8_t dataNss) override;
     void DoReportAmpduTxStatus(WifiRemoteStation* station,
                                uint16_t nSuccessfulMpdus,
                                uint16_t nFailedMpdus,
                                double rxSnr,
                                double dataSnr,
-                               uint16_t dataChannelWidth,
+                               MHz_u dataChannelWidth,
                                uint8_t dataNss) override;
     void DoReportFinalRtsFailed(WifiRemoteStation* station) override;
     void DoReportFinalDataFailed(WifiRemoteStation* station) override;
-    WifiTxVector DoGetDataTxVector(WifiRemoteStation* station, uint16_t allowedWidth) override;
+    WifiTxVector DoGetDataTxVector(WifiRemoteStation* station, MHz_u allowedWidth) override;
     WifiTxVector DoGetRtsTxVector(WifiRemoteStation* station) override;
 
     /**

--- a/examples/multi-bss/multi-bss.cc
+++ b/examples/multi-bss/multi-bss.cc
@@ -1845,7 +1845,7 @@ main(int argc, char* argv[])
     {
         // std::cout << "Datarate: " << HePhy::GetDataRate(i, channelWidths, guardIntervalNs, 1)
         //           << std::endl;
-        dataRateToMcs[HePhy::GetDataRate(i, channelWidths, guardIntervalNs, 1)] = i;
+        dataRateToMcs[HePhy::GetDataRate(i, channelWidths, NanoSeconds(guardIntervalNs), 1)] = i;
     }
 
     if (phyMode != "OfdmRate54Mbps")

--- a/examples/rate-control/constant/ai-constant-rate-wifi-manager.cc
+++ b/examples/rate-control/constant/ai-constant-rate-wifi-manager.cc
@@ -111,7 +111,7 @@ AiConstantRateWifiManager::DoReportDataOk(WifiRemoteStation* st,
                                           double ackSnr,
                                           WifiMode ackMode,
                                           double dataSnr,
-                                          uint16_t dataChannelWidth,
+                                          MHz_u dataChannelWidth,
                                           uint8_t dataNss)
 {
     NS_LOG_FUNCTION(this << st << ackSnr << ackMode << dataSnr << dataChannelWidth << +dataNss);
@@ -130,7 +130,7 @@ AiConstantRateWifiManager::DoReportFinalDataFailed(WifiRemoteStation* station)
 }
 
 WifiTxVector
-AiConstantRateWifiManager::DoGetDataTxVector(WifiRemoteStation* st, uint16_t allowedWidth)
+AiConstantRateWifiManager::DoGetDataTxVector(WifiRemoteStation* st, MHz_u allowedWidth)
 {
     NS_LOG_FUNCTION(this << st);
     Ns3AiMsgInterfaceImpl<AiConstantRateEnvStruct, AiConstantRateActStruct>* msgInterface =
@@ -162,9 +162,7 @@ AiConstantRateWifiManager::DoGetDataTxVector(WifiRemoteStation* st, uint16_t all
         m_dataMode,
         GetDefaultTxPowerLevel(),
         GetPreambleForTransmission(m_dataMode.GetModulationClass(), GetShortPreambleEnabled()),
-        ConvertGuardIntervalToNanoSeconds(m_dataMode,
-                                          GetShortGuardIntervalSupported(st),
-                                          NanoSeconds(GetGuardInterval(st))),
+        GetGuardInterval(st),
         GetNumberOfAntennas(),
         nss,
         0,
@@ -180,9 +178,7 @@ AiConstantRateWifiManager::DoGetRtsTxVector(WifiRemoteStation* st)
         m_ctlMode,
         GetDefaultTxPowerLevel(),
         GetPreambleForTransmission(m_ctlMode.GetModulationClass(), GetShortPreambleEnabled()),
-        ConvertGuardIntervalToNanoSeconds(m_ctlMode,
-                                          GetShortGuardIntervalSupported(st),
-                                          NanoSeconds(GetGuardInterval(st))),
+        GetGuardInterval(st),
         1,
         1,
         0,

--- a/examples/rate-control/constant/ai-constant-rate-wifi-manager.h
+++ b/examples/rate-control/constant/ai-constant-rate-wifi-manager.h
@@ -86,11 +86,11 @@ class AiConstantRateWifiManager : public WifiRemoteStationManager
                         double ackSnr,
                         WifiMode ackMode,
                         double dataSnr,
-                        uint16_t dataChannelWidth,
+                        MHz_u dataChannelWidth,
                         uint8_t dataNss) override;
     void DoReportFinalRtsFailed(WifiRemoteStation* station) override;
     void DoReportFinalDataFailed(WifiRemoteStation* station) override;
-    WifiTxVector DoGetDataTxVector(WifiRemoteStation* station, uint16_t allowedWidth) override;
+    WifiTxVector DoGetDataTxVector(WifiRemoteStation* station, MHz_u allowedWidth) override;
     WifiTxVector DoGetRtsTxVector(WifiRemoteStation* station) override;
 
     WifiMode m_dataMode; //!< Wifi mode for unicast Data frames

--- a/examples/rate-control/thompson-sampling/ai-thompson-sampling-wifi-manager.h
+++ b/examples/rate-control/thompson-sampling/ai-thompson-sampling-wifi-manager.h
@@ -144,18 +144,18 @@ class AiThompsonSamplingWifiManager : public WifiRemoteStationManager
                         double ackSnr,
                         WifiMode ackMode,
                         double dataSnr,
-                        uint16_t dataChannelWidth,
+                        MHz_u dataChannelWidth,
                         uint8_t dataNss) override;
     void DoReportAmpduTxStatus(WifiRemoteStation* station,
                                uint16_t nSuccessfulMpdus,
                                uint16_t nFailedMpdus,
                                double rxSnr,
                                double dataSnr,
-                               uint16_t dataChannelWidth,
+                               MHz_u dataChannelWidth,
                                uint8_t dataNss) override;
     void DoReportFinalRtsFailed(WifiRemoteStation* station) override;
     void DoReportFinalDataFailed(WifiRemoteStation* station) override;
-    WifiTxVector DoGetDataTxVector(WifiRemoteStation* station, uint16_t allowedWidth) override;
+    WifiTxVector DoGetDataTxVector(WifiRemoteStation* station, MHz_u allowedWidth) override;
     WifiTxVector DoGetRtsTxVector(WifiRemoteStation* station) override;
 
     /**

--- a/model/gym-interface/py/setup.py
+++ b/model/gym-interface/py/setup.py
@@ -21,5 +21,5 @@ from setuptools import setup
 setup(
     name="ns3ai_gym_env",
     version="0.0.1",
-    install_requires=["numpy", "gymnasium", "protobuf==3.20.3"],
+    install_requires=["numpy", "gymnasium", "protobuf"],
 )


### PR DESCRIPTION
1. Update example code to work with ns-3.43 release, such as using `MHz_u` rather than `uint16_t` for bandwidth.
2. Fix several issues for cmake: (1) add `-Wno-gcc-compat` compile option for clang, (2) fix failed generation of protobuf header and source files, and (3) change Protobuf library name from `protobuf` to `protobuf::libprotobuf`.
3. Change the deprecated `keras.backend.expand_dims` to `tf.keras.ops.expand_dims`, in `run_online_lstm.py`.
4. Update installation documentation regarding passing Python environment into cmake via `ns3` script.